### PR TITLE
Expose a getter for the model that resides inside the Lockstep state

### DIFF
--- a/src/Test/QuickCheck/StateModel/Lockstep.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep.hs
@@ -13,6 +13,7 @@
 module Test.QuickCheck.StateModel.Lockstep (
     -- * Main abstraction
     Lockstep -- opaque
+  , getModel
   , InLockstep(..)
   , RunLockstep(..)
     -- ** Convenience aliases

--- a/src/Test/QuickCheck/StateModel/Lockstep/API.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/API.hs
@@ -4,6 +4,7 @@
 module Test.QuickCheck.StateModel.Lockstep.API (
     -- * State
     Lockstep(..)
+  , getModel
     -- * Main abstraction
   , InLockstep(..)
   , RunLockstep(..)
@@ -54,6 +55,10 @@ data Lockstep state = Lockstep {
 -- | The 'Show' instance does not show the internal environment
 instance Show state => Show (Lockstep state) where
   show = show . lockstepModel
+
+-- | Inspect the model that resides inside the Lockstep state
+getModel :: Lockstep state -> state
+getModel = lockstepModel
 
 {-------------------------------------------------------------------------------
   Main lockstep abstraction


### PR DESCRIPTION
Exposing the getter enables writing custom functions that act on the model. For example:

```haskell
instance StateModel (Lockstep state) where
  {- other class methods elided -}
  precondition st act = Lockstep.precondition st act && modelPrecondition (getModel st) act
  
-- | Custom precondition
modelPrecondition :: state -> LockstepAction state a -> Bool
modelPrecondition = ...
```