### PR TITLE
Enable writing custom `InterpretOp` instances.

### DIFF
--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -49,6 +49,7 @@ library
   exposed-modules:
       Test.QuickCheck.StateModel.Lockstep
       Test.QuickCheck.StateModel.Lockstep.Defaults
+      Test.QuickCheck.StateModel.Lockstep.Op
       Test.QuickCheck.StateModel.Lockstep.Op.Identity
       Test.QuickCheck.StateModel.Lockstep.Op.SumProd
       Test.QuickCheck.StateModel.Lockstep.Run
@@ -56,7 +57,6 @@ library
       Test.QuickCheck.StateModel.Lockstep.API
       Test.QuickCheck.StateModel.Lockstep.EnvF
       Test.QuickCheck.StateModel.Lockstep.GVar
-      Test.QuickCheck.StateModel.Lockstep.Op
   build-depends:
       -- quickcheck-dynamic requires ghc 8.10 minimum
       base               >= 4.14 && < 4.18

--- a/src/Test/QuickCheck/StateModel/Lockstep/Op.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Op.hs
@@ -3,6 +3,7 @@ module Test.QuickCheck.StateModel.Lockstep.Op (
   , InterpretOp(..)
   , WrapRealized(..)
   , intOpRealizedId
+  , intOpTransformer
   ) where
 
 import Test.QuickCheck.StateModel (Realized)
@@ -27,8 +28,8 @@ class Operation op => InterpretOp op f where
 {-------------------------------------------------------------------------------
   Interop with 'Realized'
 
-  We want to execute operations against 'Realized' values, but since that is
-  a newtype, we need to wrap and unwrap in order to be able to give the
+  We want to execute operations against 'Realized' values, but since that is a
+  type family, we need to wrap and unwrap in order to be able to give the
   appropriate 'InterpretOp' instances.
 -------------------------------------------------------------------------------}
 
@@ -44,3 +45,22 @@ intOpRealizedId ::
   => (op a b -> a -> Maybe b)
   -> op a b -> WrapRealized m a -> Maybe (WrapRealized m b)
 intOpRealizedId = coerce
+
+-- | Convenience function for defining 'InterpretOp' instances for monad
+-- transformer stacks.
+intOpTransformer ::
+     forall t m a b op.
+     ( Realized (t m) a ~ Realized m a
+     , Realized (t m) b ~ Realized m b
+     , InterpretOp op (WrapRealized m)
+     )
+  => op a b
+  -> WrapRealized (t m) a
+  -> Maybe (WrapRealized (t m) b)
+intOpTransformer op wr = coerceOut <$> intOp op (coerceIn wr)
+  where
+    coerceIn :: WrapRealized (t m) a -> WrapRealized m a
+    coerceIn = coerce
+
+    coerceOut :: WrapRealized m b -> WrapRealized (t m) b
+    coerceOut = coerce

--- a/src/Test/QuickCheck/StateModel/Lockstep/Op/SumProd.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Op/SumProd.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TypeOperators #-}
-module Test.QuickCheck.StateModel.Lockstep.Op.SumProd (Op(..)) where
+module Test.QuickCheck.StateModel.Lockstep.Op.SumProd (Op(..), intOpId) where
 
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.State
@@ -47,11 +46,13 @@ instance Operation Op where
 instance InterpretOp Op (WrapRealized IO) where
   intOp = intOpRealizedId intOpId
 
-instance InterpretOp Op (WrapRealized (ReaderT r IO)) where
-  intOp = intOpRealizedId intOpId
+instance InterpretOp Op (WrapRealized m)
+      => InterpretOp Op (WrapRealized (StateT s m)) where
+  intOp = intOpTransformer
 
-instance InterpretOp Op (WrapRealized (StateT s IO)) where
-  intOp = intOpRealizedId intOpId
+instance InterpretOp Op (WrapRealized m)
+      => InterpretOp Op (WrapRealized (ReaderT r m)) where
+  intOp = intOpTransformer
 
 {-------------------------------------------------------------------------------
   'Show' and 'Eq' instances


### PR DESCRIPTION
I found that when I write `quickcheck-lockstep` tests with a `RealMonad` that is not `IO`, `ReaderT r IO` or `StateT s IO`, then I need to write my own `InterpretOp` instances for `SumProd.Op`. This PR enables writing these instances.

There's two use cases I want to enable:
* The base monad of my stack, i.e. some type `M :: Type -> Type`, behaves like the instance for `IO` because `Realized M a = a`. In this case, I can write the instance in at least two ways:

```haskell
instance InterpretOp Op (WrapRealized M) where
  intOp = intOpRealizedId intOpId
```
```haskell
deriving via WrapRealized IO instance InterpretOp Op (WrapRealized M)
```

* I have a monad transformer `T m a` that does not have an instance yet, and we have `Realized (T m) a = Realized m a`. The new `intOpTransformer` helper function makes instances composable. I can, again, write the instances in at least two ways:

```haskell
instance InterpretOp Op (WrapRealized m)
      => InterpretOp Op (WrapRealized (T m)) where
  intOp = intOpTransformer
```
```haskell
deriving via WrapRealized (StateT s m) instance InterpretOp Op (WrapRealized m) 
                                             => InterpretOp Op (WrapRealized (ReaderT r m))
```

Both use cases require exporting the `Op` module or some of its internal definitions. I am unsure what tools should be exposed, so feel free to suggest a different approach than the one I currently have.