### PR TITLE
Add `runActionsInState` and `runActionsInStateBracket`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,14 +28,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.2
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.4.2
+            compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,27 @@
 dist-newstyle
 .envrc
+
+# Haskell.gitignore
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.hie
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*

--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -13,7 +13,7 @@ description:        Lockstep-style testing is a particular approach for blackbox
                     APIs calls, then execute them both against the system under
                     test and against a model, and compare responses up to some
                     notion of observability.
-tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
+tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.4
 
 source-repository head
   type:     git


### PR DESCRIPTION
~~Both functions are similar to `runActions` and `runActionsBracket`. They only differ in that the former can be passed custom initial states to run actions on.~~

Also: updated `tested-with` ghc versions in the `.cabal` file and CI.

~~The one thing I am unsure about is that `quickcheck-dynamic` has removed `runActionsInState` in version `3.0.*`, so we are introducing something that we know will break when/if we update the `quickcheck-dynamic` dependency to `3.0.*`.~~