### PR TITLE
Bump `quickcheck-dynamic` dependency to `3.3.1`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -33,9 +33,9 @@ jobs:
             compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8

--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -13,7 +13,7 @@ description:        Lockstep-style testing is a particular approach for blackbox
                     APIs calls, then execute them both against the system under
                     test and against a model, and compare responses up to some
                     notion of observability.
-tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5 || ==9.6.2
+tested-with:        GHC ==8.10 || ==9.0 || ==9.2 || ==9.4 || ==9.6
 
 source-repository head
   type:     git
@@ -59,12 +59,12 @@ library
       Test.QuickCheck.StateModel.Lockstep.GVar
   build-depends:
       -- quickcheck-dynamic requires ghc 8.10 minimum
-      base               >= 4.14 && < 4.19
-    , constraints        >= 0.13 && < 0.14
-    , mtl                >= 2.2  && < 2.4
-    , containers         >= 0.6  && < 0.7
-    , QuickCheck         >= 2.14 && < 2.15
-    , quickcheck-dynamic >= 2.0  && < 2.1
+      base               >= 4.14   && < 4.19
+    , constraints        >= 0.13   && < 0.14
+    , mtl                >= 2.2    && < 2.4
+    , containers         >= 0.6    && < 0.7
+    , QuickCheck         >= 2.14   && < 2.15
+    , quickcheck-dynamic >= 3.3.1  && < 3.4
   hs-source-dirs:
       src
 

--- a/src/Test/QuickCheck/StateModel/Lockstep/EnvF.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/EnvF.hs
@@ -21,7 +21,7 @@ import Data.Foldable (asum)
 import Data.Maybe (mapMaybe)
 import Data.Typeable
 
-import Test.QuickCheck.StateModel (Var(..))
+import Test.QuickCheck.StateModel.Variables (Var, unsafeCoerceVar)
 
 {-------------------------------------------------------------------------------
   Types
@@ -51,8 +51,8 @@ lookup = \var (EnvF env) ->
     asum $ map (\(EnvEntry var' fa') -> aux var var' fa') env
   where
     aux :: Typeable a' => Var a -> Var a' -> f a' -> Maybe (f a)
-    aux (Var x) (Var y) fa' = do
-        guard (x == y)
+    aux v1 v2 fa' = do
+        guard (v1 == unsafeCoerceVar v2)
         cast fa'
 
 keysOfType :: Typeable a => EnvF f -> [Var a]

--- a/src/Test/QuickCheck/StateModel/Lockstep/GVar.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/GVar.hs
@@ -21,7 +21,7 @@ import Prelude hiding (map)
 import Data.Maybe (isJust, fromJust)
 import Data.Typeable
 
-import Test.QuickCheck.StateModel (Var(..), LookUp, Realized)
+import Test.QuickCheck.StateModel (Var, LookUp, Realized)
 
 import Test.QuickCheck.StateModel.Lockstep.EnvF (EnvF)
 import Test.QuickCheck.StateModel.Lockstep.EnvF qualified as EnvF

--- a/src/Test/QuickCheck/StateModel/Lockstep/Run.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Run.hs
@@ -69,7 +69,7 @@ labelActions (Actions steps) =
   where
     go :: Set String -> Lockstep state -> [Step (Lockstep state)] -> [String]
     go tags _st []            = Set.toList tags
-    go tags  st ((v:=a) : ss) = go' tags st v a ss
+    go tags  st ((v:=a) : ss) = go' tags st v (polarAction a) ss
 
     go' :: forall a.
          Typeable a

--- a/test/Test/MockFS.hs
+++ b/test/Test/MockFS.hs
@@ -32,7 +32,7 @@ import Test.Tasty.QuickCheck (testProperty)
 
 import Test.QuickCheck (Gen)
 import Test.QuickCheck qualified as QC
-import Test.QuickCheck.StateModel
+import Test.QuickCheck.StateModel hiding (vars)
 
 import Test.QuickCheck.StateModel.Lockstep
 import Test.QuickCheck.StateModel.Lockstep.Defaults qualified as Lockstep


### PR DESCRIPTION
Fixes required for the bump to `q-d-3.0`:
* We don't have access to the `Var` constructor anymore.
* `arbitraryAction` and `shrinkAction` now have an additional `VarContext` parameter.
* There is a new `HasVariables` class that is required for both `state` and `Action`.

Fixes required for the bump to `q-d-3.1`:
* A `postcondition` should now return a `PostconditionM m Bool` instead of `m Bool`.

Fixes required for the bump to `q-d-3.2`:
* A `Step` now contains an `ActionWithPolarity` instead of an `Action`, which was easily fixed by unwrapping the `ActionWithPolarity` to an `Action` in one place in the code.

I've also updated the GitHub actions workflow file to run with the latest `ghc` versions for previous major versions.