### PR TITLE
Fix counter-examples to produce valid code

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -33,14 +33,14 @@ jobs:
             compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.6.4
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.6.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Revision history for quickcheck-lockstep
 
-## next release
+## 0.4.0 -- 2024-02-17
 
+* BREAKING: Counter-examples now produce valid code. To facilitate this,
+  `HasVariables` and `Show` instances have changed, and a new `unsafeMkGVar`
+  smart constructor is exposed.
 * Add compatibility with ghc-9.8
 
 ## 0.3.0 -- 2023-10-17

--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               quickcheck-lockstep
-version:            0.3.0
+version:            0.4.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Edsko de Vries

--- a/src/Test/QuickCheck/StateModel/Lockstep.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep.hs
@@ -24,6 +24,7 @@ module Test.QuickCheck.StateModel.Lockstep (
     -- * Variables
   , GVar -- opaque
   , AnyGVar(..)
+  , unsafeMkGVar
   , lookUpGVar
   , mapGVar
     -- ** Operations

--- a/src/Test/QuickCheck/StateModel/Lockstep/Defaults.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Defaults.hs
@@ -137,12 +137,13 @@ monitoring _p (before, after) action _lookUp _realResp =
 instance HasVariables (Lockstep state) where
   getAllVariables _ = Set.empty
 
--- | Ignore variables for lockstep actions.
+-- | Do not ignore variables for lockstep actions.
 --
--- We largely ignore @quickcheck-dynamic@'s variables in the lockstep framework,
--- since it does its own accounting of model variables.
-instance HasVariables (Action (Lockstep state) a) where
-  getAllVariables _ = Set.empty
+-- @quickcheck-dynamic@ prints counterexamples as code that is more or less
+-- runnable, which requires a sensible 'HasVariables' instance for lockstep
+-- actions.
+instance InLockstep state => HasVariables (Action (Lockstep state) a) where
+  getAllVariables = Set.unions . fmap getAllVariables . usedVars
 
 {-------------------------------------------------------------------------------
   Internal auxiliary

--- a/src/Test/QuickCheck/StateModel/Lockstep/Op/SumProd.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Op/SumProd.hs
@@ -93,10 +93,9 @@ instance Show (Op a b) where
       _        -> go op
     where
       go :: Op x y -> String -> String
-      go OpId         = showString "id"
-      go OpFst        = showString "fst"
-      go OpSnd        = showString "snd"
-      go OpLeft       = showString "fromLeft"
-      go OpRight      = showString "fromRight"
-      go (OpComp g f) = go g . showString " . " . go f
-
+      go OpId         = showString "OpId"
+      go OpFst        = showString "OpFst"
+      go OpSnd        = showString "OpSnd"
+      go OpLeft       = showString "OpLeft"
+      go OpRight      = showString "OpRight"
+      go (OpComp g f) = go g . showString " `OpComp` " . go f


### PR DESCRIPTION
Resolves #13, which was submitted by @dcoutts. 

The fix included the following changes:
* Make a proper `HasVariables` instance for lockstep actions, which reuses `usedVars` from the `InLockstep` class. Previously, the instance would just return the empty set, but this meant that counter-example printing would never bind variables.
* Changed some `Show` instances to produce valid code.
* Added a new `mkGVar` smart constructor that is used in counterexamples.

We're slightly breaking the abstraction by exposing `mkGVar`, whereas previously the user could only use `mapGVar` or `lookupGVar`.

### Before

```haskell
*** Found example of Tags: ["OpenTwo","SuccessfulRead"]
do action $ Open (File {dir = Dir [], name = "t0"})
   action $ Close (GVar var5 (fst . fromRight . id))
   action $ Read (Left (GVar var5 (snd . fromRight . id)))
   action $ Open (File {dir = Dir [], name = "t1"})
   pure ()

```

### After

```haskell
*** Found example of Tags: ["OpenTwo","SuccessfulRead"]
do var71 <- action $ Open (File {dir = Dir [], name = "t1"})
   action $ Close (mkGVar var71 (OpFst `OpComp` OpRight `OpComp` OpId))
   action $ Open (File {dir = Dir [], name = "t0"})
   action $ Read (Left (mkGVar var71 (OpSnd `OpComp` OpRight `OpComp` OpId)))
   pure ()
```