### PR TITLE
Fix build with mtl^>=2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for quickcheck-lockstep
 
+## 0.4.1 -- 2024-02-21
+
+* PATCH: fix compilation failures when using `mtl ^>=2.3`
+
 ## 0.4.0 -- 2024-02-17
 
 * BREAKING: Counter-examples now produce valid code. To facilitate this,

--- a/src/Test/QuickCheck/StateModel/Lockstep/Op/SumProd.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Op/SumProd.hs
@@ -1,12 +1,8 @@
-{-# LANGUAGE CPP #-}
-
 module Test.QuickCheck.StateModel.Lockstep.Op.SumProd (Op(..), intOpId) where
 
-#if __GLASGOW_HASKELL__ >= 906
 import Control.Monad ((<=<))
-#endif
 import Control.Monad.Reader (ReaderT)
-import Control.Monad.State
+import Control.Monad.State (StateT)
 import GHC.Show (appPrec)
 
 import Test.QuickCheck.StateModel.Lockstep.Op

--- a/src/Test/QuickCheck/StateModel/Lockstep/Run.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Run.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 -- | Run lockstep tests
 --
 -- Intended for qualified import.
@@ -17,11 +15,7 @@ module Test.QuickCheck.StateModel.Lockstep.Run (
 import Prelude hiding (init)
 
 import Control.Exception
-#if __GLASGOW_HASKELL__ >= 906
 import Control.Monad (void)
-#else
-import Control.Monad.Reader
-#endif
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Typeable

--- a/test/Test/MockFS.hs
+++ b/test/Test/MockFS.hs
@@ -16,8 +16,8 @@ module Test.MockFS (tests) where
 import Prelude hiding (init)
 
 import Control.Exception (catch, throwIO)
-import Control.Monad
-import Control.Monad.Reader
+import Control.Monad (replicateM, (<=<))
+import Control.Monad.Reader (ReaderT (..))
 import Data.Bifunctor
 import Data.Set (Set)
 import Data.Set qualified as Set


### PR DESCRIPTION
Apparently, without constraints the lib will pick `mtl-2.2` on `ghc-2.8`. However, if we force the use of `mtl-2.3`, then we get compilation failures. This PR fixes those failures

```sh
$ cabal freeze --with-compiler="ghc-9.2.8"
$ cabal freeze --with-compiler="ghc-9.2.8" --constraint="mtl^>=2.3"
```

```diff
diff --git a/cabal.project.freeze b/cabal.project.freeze
index c11278a..443478a 100644
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -15,14 +15,15 @@ constraints: any.QuickCheck ==2.14.3,
              any.data-array-byte ==0.1.0.1,
              any.deepseq ==1.4.6.1,
              any.directory ==1.3.6.2,
-             any.exceptions ==0.10.4,
+             any.exceptions ==0.10.7,
+             exceptions +transformers-0-4,
              any.filepath ==1.4.2.2,
              any.ghc-bignum ==1.2,
              any.ghc-boot-th ==9.2.8,
              any.ghc-prim ==0.8.0,
              any.hashable ==1.4.3.0,
              hashable +integer-gmp -random-initial-seed,
-             any.mtl ==2.2.2,
+             any.mtl ==2.3.1,
              any.optparse-applicative ==0.18.1.0,
              optparse-applicative +process,
              any.pretty ==1.1.3.6,
```

