### PR TITLE
Introduce `ModelVarContext` as a generalisation of `ModelLookup` and `ModelFindVariables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Revision history for quickcheck-lockstep
 
+## ?.?.? -- ????-??-??
+
+* BREAKING: Generalise `ModelFindVariables` and `ModelLookup` to
+  `ModelVarContext`. Occurrences of `ModelFindVariables` and `ModelLookup` in
+  the `InLockstep` class are replaced by the newly exposed `ModelVarContext`. A
+  `ModelFindVariables` can be recovered from a `ModelVarContext` using the new
+  `findVars` functions. A `ModelLookup` can be recovered from a
+  `ModelVarContext` using the new `lookupVars` function. Since these functions
+  can be recovered from `ModelVarContext`, existing tests are guaranteed to be
+  adaptable to the new `InLockstep` API. This breaking changes means that, for
+  example ...
+  ```haskell
+  arbitraryWithVars lookupVars = ...
+    (lookupVars ...)
+  ```
+  ... should be changed to ...
+  ```haskell
+  arbitraryWithVars vctx = ...
+    (lookupVars vctx ...)
+  ```
+
 ## 0.5.1 -- 2024-08-27
 
 * PATCH: allow building with `ghc-9.10`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for quickcheck-lockstep
 
-## ?.?.? -- ????-??-??
+## 0.6.0 -- 2024-12-03
 
 * BREAKING: Generalise `ModelFindVariables` and `ModelLookup` to
   `ModelVarContext`. Occurrences of `ModelFindVariables` and `ModelLookup` in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Library for lockstep-style testing with `quickcheck-dynamic`
+# quickcheck-lockstep
+
+[![Hackage Version](https://img.shields.io/hackage/v/quickcheck-lockstep?label=hackage%20quickcheck-lockstep)](https://hackage.haskell.org/package/quickcheck-lockstep)
+[![Haskell CI](https://img.shields.io/github/actions/workflow/status/well-typed/quickcheck-lockstep/haskell.yml?label=Build)](https://github.com/well-typed/quickcheck-lockstep/actions/workflows/haskell.yml)
+
+`quickcheck-lockstep` is a library for lockstep-style testing with `quickcheck-dynamic`
 
 See https://well-typed.com/blog/2022/09/lockstep-with-quickcheck-dynamic/
 for a tutorial.

--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            quickcheck-lockstep
-version:         0.5.1
+version:         0.6.0
 license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Edsko de Vries

--- a/src/Test/QuickCheck/StateModel/Lockstep.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep.hs
@@ -21,6 +21,10 @@ module Test.QuickCheck.StateModel.Lockstep (
   , ModelFindVariables
   , ModelLookUp
   , ModelVar
+    -- * Variable context
+  , ModelVarContext
+  , lookupVar
+  , findVars
     -- * Variables
   , GVar -- opaque
   , AnyGVar(..)

--- a/src/Test/QuickCheck/StateModel/Lockstep/Run.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Run.hs
@@ -30,7 +30,6 @@ import Test.QuickCheck.StateModel qualified as StateModel
 
 import Test.QuickCheck.StateModel.Lockstep.API
 import Test.QuickCheck.StateModel.Lockstep.EnvF qualified as EnvF
-import Test.QuickCheck.StateModel.Lockstep.GVar
 
 {-------------------------------------------------------------------------------
   Finding labelled examples
@@ -83,7 +82,7 @@ labelActions (Actions steps) =
 
         modelResp :: ModelValue state a
         after     :: state
-        (modelResp, after) = modelNextState action (lookUpEnvF env) before
+        (modelResp, after) = modelNextState action env before
 
         tags' :: [String]
         tags' = tagStep (before, after) action modelResp

--- a/test/Test/IORef/Full.hs
+++ b/test/Test/IORef/Full.hs
@@ -124,11 +124,11 @@ instance InLockstep M where
   usedVars (Write v (Right v')) = [SomeGVar v, SomeGVar v']
   usedVars (Read  v)            = [SomeGVar v]
 
-  modelNextState = runModel
+  modelNextState action ctx = runModel action (lookupVar ctx)
 
-  arbitraryWithVars findVars _mock = oneof $ concat [
+  arbitraryWithVars ctx _mock = oneof $ concat [
         withoutVars
-      , case findVars (Proxy @(IORef Int)) of
+      , case findVars ctx (Proxy @(IORef Int)) of
           []   -> []
           vars -> withVars (elements vars)
       ]
@@ -144,11 +144,11 @@ instance InLockstep M where
           , fmap Some $ Read  <$> genVar
           ]
 
-  shrinkWithVars findVars _mock = \case
+  shrinkWithVars ctx _mock = \case
       New               -> []
       Write v (Left x)  -> concat [
                                Some . Write v . Left  <$> shrink x
-                             , Some . Write v . Right <$> findVars (Proxy @Int)
+                             , Some . Write v . Right <$> findVars ctx (Proxy @Int)
                              ]
       Write _ (Right _) -> []
       Read  _           -> []

--- a/test/Test/IORef/Simple.hs
+++ b/test/Test/IORef/Simple.hs
@@ -101,11 +101,11 @@ instance InLockstep M where
   usedVars (Write v _) = [SomeGVar v]
   usedVars (Read  v)   = [SomeGVar v]
 
-  modelNextState = runModel
+  modelNextState action ctx = runModel action (lookupVar ctx)
 
-  arbitraryWithVars findVars _mock = oneof $ concat [
+  arbitraryWithVars ctx _mock = oneof $ concat [
         withoutVars
-      , case findVars (Proxy @(IORef Int)) of
+      , case findVars ctx (Proxy @(IORef Int)) of
           []   -> []
           vars -> withVars (elements vars)
       ]


### PR DESCRIPTION
Occurrences of `ModelFindVariables` and `ModelLookup` in the `InLockstep` class are replaced by the newly exposed `ModelVarContext`. A `ModelFindVariables` can be recovered from a `ModelVarContext` using the new `findVars` functions. A `ModelLookup` can be recovered from a `ModelVarContext` using the new `lookupVars` function. Since these functions can be recovered from `ModelVarContext`, existing tests are guaranteed to be adaptable to the new `InLockstep` API.

Motivation: previously in the `InLockstep` class, member functions would be passed a `ModelFindVariables` or a `ModelLookup`, but never both. In practice this turned out to be too restrictive, because one might want access to both in the same function, see https://github.com/IntersectMBO/lsm-tree/pull/431. For example, `arbitraryWithVars` was previously only passed a `ModelFindVariables`, but without a `ModelLookup` one can not filter these variables based on the (modelled) outcome of the corresponding actions. The use case for #431 in particular was to filter variables that reference stateful handles (e.g., file handles) for handles that are open. Because of this filtering, one can skew the action distribution to generate more actions on open handles. It is often more interesting to test actions on open handles than it is to test actions on closed handles, which will presumably always return the same error.