### PR TITLE
Print all responses in counterexamples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.golden	-text

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 dist-newstyle
 .envrc
+_tmp
+haddocks/
 
 # Haskell.gitignore
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for quickcheck-lockstep
 
+## ?.?.? -- ????-??-??
+
+* BREAKING: Enable verbose counterexamples by default in the 'postcondition'
+  function using 'postconditionWith'.
+* NON-BREAKING: Add a new 'postconditionWith' function that can be configured to
+  produce more verbose counterexamples. With verbosity disabled, all states of
+  the model are printed in a counterexample. If verbosity is enabled, the
+  counterexample will also include all responses from the real system and the
+  model.
+
 ## 0.6.0 -- 2024-12-03
 
 * BREAKING: Generalise `ModelFindVariables` and `ModelLookup` to

--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -80,6 +80,7 @@ test-suite test-quickcheck-lockstep
   hs-source-dirs:     test
   main-is:            Main.hs
   other-modules:
+    Test.Golden
     Test.IORef.Full
     Test.IORef.Simple
     Test.MockFS
@@ -101,6 +102,7 @@ test-suite test-quickcheck-lockstep
     , quickcheck-dynamic
     , quickcheck-lockstep
     , tasty
+    , tasty-golden
     , tasty-hunit
     , tasty-quickcheck
     , temporary

--- a/src/Test/QuickCheck/StateModel/Lockstep/Defaults.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep/Defaults.hs
@@ -100,7 +100,7 @@ postcondition :: forall m state a.
   -> LookUp m
   -> Realized m a
   -> PostconditionM m Bool
-postcondition = postconditionWith False
+postcondition = postconditionWith True
 
 -- | Like 'postcondition', but with configurable verbosity.
 --

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,14 +1,16 @@
 module Main (main) where
 
-import Test.Tasty
+import           Test.Tasty
 
-import Test.IORef.Full   qualified
-import Test.IORef.Simple qualified
-import Test.MockFS       qualified
+import           Test.Golden
+import           Test.IORef.Full
+import           Test.IORef.Simple
+import           Test.MockFS
 
 main :: IO ()
 main = defaultMain $ testGroup "quickcheck-lockstep" [
-      Test.IORef.Simple.tests
+      Test.Golden.tests
+    , Test.IORef.Simple.tests
     , Test.IORef.Full.tests
     , Test.MockFS.tests
     ]

--- a/test/Test/Golden.hs
+++ b/test/Test/Golden.hs
@@ -1,0 +1,107 @@
+{- HLINT ignore "Use camelCase" -}
+
+module Test.Golden where
+
+import           Control.Exception      (bracket_)
+import           System.Directory
+import           System.FilePath
+import           Test.MockFS            as MockFS
+import           Test.QuickCheck
+import           Test.QuickCheck.Random (mkQCGen)
+import           Test.Tasty
+import           Test.Tasty.Golden
+
+tests :: TestTree
+tests = testGroup "Test.Golden" [
+      golden_success_propLockstep_MockFS
+    , golden_failure_default_propLockstep_MockFS
+    , golden_failure_nonVerbose_propLockstep_MockFS
+    , golden_failure_verbose_propLockstep_MockFS
+    ]
+
+goldenDir :: FilePath
+goldenDir = "test" </> "golden"
+
+tmpDir :: FilePath
+tmpDir = "_tmp"
+
+-- | Golden test for a successful lockstep test
+golden_success_propLockstep_MockFS :: TestTree
+golden_success_propLockstep_MockFS =
+    goldenVsFile testName goldenPath outputPath $ do
+      createDirectoryIfMissing False tmpDir
+      r <- quickCheckWithResult args MockFS.propLockstep
+      writeFile outputPath (output r)
+  where
+    testName = "golden_success_propLockstep_MockFS"
+    goldenPath = goldenDir </> testName <.> "golden"
+    outputPath = tmpDir </> testName <.> "golden"
+
+    args = stdArgs {
+        replay = Just (mkQCGen 17, 32)
+      , chatty = False
+      }
+
+-- | Golden test for a failing lockstep test that produces a counterexample
+-- using the default postcondition.
+golden_failure_default_propLockstep_MockFS :: TestTree
+golden_failure_default_propLockstep_MockFS =
+    goldenVsFile testName goldenPath outputPath $ do
+      createDirectoryIfMissing False tmpDir
+      r <-
+        bracket_
+          MockFS.setInduceFault
+          MockFS.setNoInduceFault
+          (quickCheckWithResult args MockFS.propLockstep)
+      writeFile outputPath (output r)
+  where
+    testName = "golden_failure_default_propLockstep_MockFS"
+    goldenPath = goldenDir </> testName <.> "golden"
+    outputPath = tmpDir </> testName <.> "golden"
+
+    args = stdArgs {
+        replay = Just (mkQCGen 17, 32)
+      , chatty = False
+      }
+
+-- | Golden test for a failing lockstep test that produces a /non-verbose/ counterexample
+golden_failure_nonVerbose_propLockstep_MockFS :: TestTree
+golden_failure_nonVerbose_propLockstep_MockFS =
+    goldenVsFile testName goldenPath outputPath $ do
+      createDirectoryIfMissing False tmpDir
+      r <-
+        bracket_
+          (MockFS.setInduceFault >> MockFS.setPostconditionNonVerbose)
+          (MockFS.setNoInduceFault >> MockFS.setPostconditionDefault)
+          (quickCheckWithResult args MockFS.propLockstep)
+      writeFile outputPath (output r)
+  where
+    testName = "golden_failure_nonVerbose_propLockstep_MockFS"
+    goldenPath = goldenDir </> testName <.> "golden"
+    outputPath = tmpDir </> testName <.> "golden"
+
+    args = stdArgs {
+        replay = Just (mkQCGen 17, 32)
+      , chatty = False
+      }
+
+-- | Golden test for a failing lockstep test that produces a /verbose/ counterexample
+golden_failure_verbose_propLockstep_MockFS :: TestTree
+golden_failure_verbose_propLockstep_MockFS =
+    goldenVsFile testName goldenPath outputPath $ do
+      createDirectoryIfMissing False tmpDir
+      r <-
+        bracket_
+          (MockFS.setInduceFault >> MockFS.setPostconditionVerbose)
+          (MockFS.setNoInduceFault >> MockFS.setPostconditionDefault)
+          (quickCheckWithResult args MockFS.propLockstep)
+      writeFile outputPath (output r)
+  where
+    testName = "golden_failure_verbose_propLockstep_MockFS"
+    goldenPath = goldenDir </> testName <.> "golden"
+    outputPath = tmpDir </> testName <.> "golden"
+
+    args = stdArgs {
+        replay = Just (mkQCGen 17, 32)
+      , chatty = False
+      }

--- a/test/golden/golden_failure_default_propLockstep_MockFS.golden
+++ b/test/golden/golden_failure_default_propLockstep_MockFS.golden
@@ -1,0 +1,18 @@
+*** Failed! Assertion failed (after 40 tests and 9 shrinks):
+do var1 <- action $ Open (File {dir = Dir [], name = "t0"})
+   action $ Write (unsafeMkGVar var1 (OpFst `OpComp` OpRight `OpComp` OpId)) "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA"
+   action $ Close (unsafeMkGVar var1 (OpFst `OpComp` OpRight `OpComp` OpId))
+   action $ Read (Left (unsafeMkGVar var1 (OpSnd `OpComp` OpRight `OpComp` OpId)))
+   pure ()
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"")], open = fromList [(0,File {dir = Dir [], name = "t0"})], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OPair (OHandle,OId (File {dir = Dir [], name = "t0"}))))
+Model returned:             OEither (Right (OPair (OHandle,OId (File {dir = Dir [], name = "t0"})))) (MEither (Right (MPair (MHandle 0,MFile (File {dir = Dir [], name = "t0"})))))
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [(0,File {dir = Dir [], name = "t0"})], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId ())) (Right ())
+Model returned:             OEither (Right (OId ())) (MEither (Right (MUnit ())))
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId ())) (Right ())
+Model returned:             OEither (Right (OId ())) (MEither (Right (MUnit ())))
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId "")) (Right "")
+but model returned:         OEither (Right (OId "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")) (MEither (Right (MString "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")))

--- a/test/golden/golden_failure_nonVerbose_propLockstep_MockFS.golden
+++ b/test/golden/golden_failure_nonVerbose_propLockstep_MockFS.golden
@@ -1,0 +1,12 @@
+*** Failed! Assertion failed (after 40 tests and 9 shrinks):
+do var1 <- action $ Open (File {dir = Dir [], name = "t0"})
+   action $ Write (unsafeMkGVar var1 (OpFst `OpComp` OpRight `OpComp` OpId)) "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA"
+   action $ Close (unsafeMkGVar var1 (OpFst `OpComp` OpRight `OpComp` OpId))
+   action $ Read (Left (unsafeMkGVar var1 (OpSnd `OpComp` OpRight `OpComp` OpId)))
+   pure ()
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"")], open = fromList [(0,File {dir = Dir [], name = "t0"})], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [(0,File {dir = Dir [], name = "t0"})], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId "")) (Right "")
+but model returned:         OEither (Right (OId "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")) (MEither (Right (MString "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")))

--- a/test/golden/golden_failure_verbose_propLockstep_MockFS.golden
+++ b/test/golden/golden_failure_verbose_propLockstep_MockFS.golden
@@ -1,0 +1,18 @@
+*** Failed! Assertion failed (after 40 tests and 9 shrinks):
+do var1 <- action $ Open (File {dir = Dir [], name = "t0"})
+   action $ Write (unsafeMkGVar var1 (OpFst `OpComp` OpRight `OpComp` OpId)) "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA"
+   action $ Close (unsafeMkGVar var1 (OpFst `OpComp` OpRight `OpComp` OpId))
+   action $ Read (Left (unsafeMkGVar var1 (OpSnd `OpComp` OpRight `OpComp` OpId)))
+   pure ()
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"")], open = fromList [(0,File {dir = Dir [], name = "t0"})], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OPair (OHandle,OId (File {dir = Dir [], name = "t0"}))))
+Model returned:             OEither (Right (OPair (OHandle,OId (File {dir = Dir [], name = "t0"})))) (MEither (Right (MPair (MHandle 0,MFile (File {dir = Dir [], name = "t0"})))))
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [(0,File {dir = Dir [], name = "t0"})], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId ())) (Right ())
+Model returned:             OEither (Right (OId ())) (MEither (Right (MUnit ())))
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId ())) (Right ())
+Model returned:             OEither (Right (OId ())) (MEither (Right (MUnit ())))
+State: FsState {fsStateMock = M {dirs = fromList [Dir []], files = fromList [(File {dir = Dir [], name = "t0"},"BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")], open = fromList [], next = 1}, fsStateStats = fromList [File {dir = Dir [], name = "t0"}]}
+System under test returned: OEither (Right (OId "")) (Right "")
+but model returned:         OEither (Right (OId "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")) (MEither (Right (MString "BAACCCCCCBCCAAAABBBBCBBABACCACBABCCACCA")))

--- a/test/golden/golden_success_propLockstep_MockFS.golden
+++ b/test/golden/golden_success_propLockstep_MockFS.golden
@@ -1,0 +1,19 @@
++++ OK, passed 100 tests.
+
+Action polarity (2489 in total):
+100.00% +
+
+Actions (2489 in total):
+30.33% +MkDir
+28.93% +Open
+27.92% +Read
+ 6.79% +Write
+ 6.03% +Close
+
+Actions rejected by precondition (958 in total):
+52.0% Close
+48.0% Write
+
+Tags (428 in total):
+92.3% OpenTwo
+ 7.7% SuccessfulRead


### PR DESCRIPTION
From the changelog:

```
* BREAKING: Enable verbose counterexamples by default in the 'postcondition'
  function using 'postconditionWith'.
* NON-BREAKING: Add a new 'postconditionWith' function that can be configured to
  produce more verbose counterexamples. With verbosity disabled, all states of
  the model are printed in a counterexample. If verbosity is enabled, the
  counterexample will also include all responses from the real system and the
  model.
```