### PR TITLE
Tweak variable context helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## ?.?.? -- ????-??-??
 
+* BREAKING: Rename `lookupGVar` to `realLookupVar`, and add a `RealLookup`
+  convenience alias that is used in the type of `RealLookupVar`. The type of
+  `realLookupVar` is slightly different than the type of `lookupGVar`, but only
+  in the positions of universal quantification over types.
+* NON-BREAKING: improved error messages for `realLookupVar` and `lookupVar`,
+  which might throw an error when variables are ill-defined or unevaluable.
+* PATCH: some documentation is moved from convenience aliases like
+  `ModelFindVariables` to the functions have these aliases in their type, like
+  `findVars`.
 * BREAKING: Enable verbose counterexamples by default in the 'postcondition'
   function using 'postconditionWith'.
 * NON-BREAKING: Add a new 'postconditionWith' function that can be configured to

--- a/src/Test/QuickCheck/StateModel/Lockstep.hs
+++ b/src/Test/QuickCheck/StateModel/Lockstep.hs
@@ -22,16 +22,17 @@ module Test.QuickCheck.StateModel.Lockstep (
   , ModelLookUp
   , ModelShrinkVar
   , ModelVar
+  , RealLookUp
     -- * Variable context
   , ModelVarContext
   , lookupVar
   , findVars
   , shrinkVar
+  , realLookupVar
     -- * Variables
   , GVar -- opaque
   , AnyGVar(..)
   , unsafeMkGVar
-  , lookUpGVar
   , mapGVar
     -- ** Operations
   , Operation(..)

--- a/test/Test/IORef/Full.hs
+++ b/test/Test/IORef/Full.hs
@@ -208,11 +208,11 @@ runIO action lookUp = ReaderT $ \(buggy, brokenRef) ->
       Read  v   -> readIORef (lookUpRef v)
   where
     lookUpRef :: ModelVar M (IORef Int) -> IORef Int
-    lookUpRef = lookUpGVar (Proxy @RealMonad) lookUp
+    lookUpRef = realLookupVar (Proxy @RealMonad) lookUp
 
     lookUpInt :: Either Int (ModelVar M Int) -> Int
     lookUpInt (Left  x) = x
-    lookUpInt (Right v) = lookUpGVar (Proxy @RealMonad) lookUp v
+    lookUpInt (Right v) = realLookupVar (Proxy @RealMonad) lookUp v
 
 -- | The second write to the same variable will be broken
 brokenWrite :: Buggy -> IORef BrokenRef -> IORef Int -> Int -> IO Int

--- a/test/Test/IORef/Simple.hs
+++ b/test/Test/IORef/Simple.hs
@@ -155,7 +155,7 @@ runIO action lookUp =
       Read  v   -> readIORef (lookUpRef v)
   where
     lookUpRef :: ModelVar M (IORef Int) -> IORef Int
-    lookUpRef = lookUpGVar (Proxy @RealMonad) lookUp
+    lookUpRef = realLookupVar (Proxy @RealMonad) lookUp
 
 runModel ::
      Action (Lockstep M) a

--- a/test/Test/MockFS.hs
+++ b/test/Test/MockFS.hs
@@ -351,7 +351,7 @@ runIO action lookUp = ReaderT $ \root -> aux root action
             _                     -> pure s
       where
         lookUp' :: FsVar x -> x
-        lookUp' = lookUpGVar (Proxy @RealMonad) lookUp
+        lookUp' = realLookupVar (Proxy @RealMonad) lookUp
 
 catchErr :: forall a. IO a -> IO (Either Err a)
 catchErr act = catch (Right <$> act) handler


### PR DESCRIPTION
Changes to the public API include:

* For uniformity, use universal quantification inside of the `ModelShrinkVar`
  type synynom instead of outside it. This is in line with how other convenience
  type aliases are defined. This does not require a changelog entry, because the
  feature for shrinking variables has not been published in an official release
  yet.

* Rename `lookupGVar` to `realLookupVar`, and add a `RealLookup` convenience alias
  that is used in the type of `RealLookupVar`. The type of `realLookupVar` is
  slightly different than the type of `lookupGVar`, but only in the positions of
  universal quantification over types.

* Improve error messages for `realLookupVar` and `lookupVar`, which might
  throw an error when variables are ill-defined or unevaluable.

* Some documentation is moved from convenience aliases like `ModelFindVariables`
  to the functions have these aliases in their type, like `findVars`.

Internally, `lookUpGVar` and `lookUpEnvF` are now total functions.
`modelLookupVar` and `realLookupVar` are now partial instead, and should provide
more useful error messages since we are no longer using `fromJust`.