### PR TITLE
Put upper bounds on all `base` dependencies

### DIFF
--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -99,7 +99,7 @@ test-suite test-quickcheck-lockstep
 
   -- Version bounds determined by main lib
   build-depends:
-    , base
+    , base < 5
     , constraints
     , containers
     , directory
@@ -131,7 +131,7 @@ test-suite test-internals
 
   -- Version bounds determined by main lib
   build-depends:
-    , base
+    , base < 5
     , quickcheck-dynamic
     , tasty
     , mtl


### PR DESCRIPTION
Otherwise Hackage doesn't accept package uploads