### PR TITLE
Support `QuickCheck-2.16`, release `quickcheck-lockstep-0.8.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for quickcheck-lockstep
 
+## 0.8.1 -- 2025-07-18
+
+* PATCH: support `QuickCheck-2.16`
+
 ## 0.8.0 -- 2025-07-03
 
 * BREAKING: Support `quickcheck-dynamic-4`. Going from version 3 to 4, some

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,7 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: release quickcheck-lockstep-0.8.0
-  , hackage.haskell.org 2025-07-03T00:00:00Z
+  -- current date: QuickCheck-2.16
+  , hackage.haskell.org 2025-07-18T00:00:00Z
 
 packages: .
 

--- a/quickcheck-lockstep.cabal
+++ b/quickcheck-lockstep.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            quickcheck-lockstep
-version:         0.8.0
+version:         0.8.1
 license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Edsko de Vries
@@ -34,10 +34,10 @@ source-repository head
   type:     git
   location: https://github.com/well-typed/quickcheck-lockstep
 
-source-repository head
+source-repository this
   type:     git
   location: https://github.com/well-typed/quickcheck-lockstep
-  tag:      quickcheck-lockstep-0.8.0
+  tag:      quickcheck-lockstep-0.8.1
 
 common language
   -- This is at the top-level so that `cabal check` does not complain.
@@ -143,7 +143,7 @@ library
     , constraints         ^>=0.13 || ^>=0.14
     , containers          ^>=0.6  || ^>=0.7  || ^>=0.8
     , mtl                 ^>=2.2  || ^>=2.3
-    , QuickCheck          ^>=2.14 || ^>=2.15
+    , QuickCheck          ^>=2.14 || ^>=2.15 || ^>=2.16
     , quickcheck-dynamic  ^>=4.0
 
   hs-source-dirs:  src

--- a/test/Test/IORef/Full.hs
+++ b/test/Test/IORef/Full.hs
@@ -12,7 +12,8 @@ import           Data.IORef
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Proxy
-import           Test.QuickCheck
+import           Test.QuickCheck (Arbitrary (..), Gen, Property, choose,
+                     elements, expectFailure, oneof)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)

--- a/test/Test/IORef/Simple.hs
+++ b/test/Test/IORef/Simple.hs
@@ -11,7 +11,7 @@ import           Data.IORef
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Proxy
-import           Test.QuickCheck
+import           Test.QuickCheck (Gen, Property, choose, elements, oneof)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck (testProperty)
 


### PR DESCRIPTION
Resolves #38 